### PR TITLE
[fix]paramsからidを取得する動作を非同期処理に変更

### DIFF
--- a/app/group/[id]/page.tsx
+++ b/app/group/[id]/page.tsx
@@ -7,7 +7,8 @@ interface Params {
   id: number;
 }
 
-const group = async ({ params: { id } }: { params: Params }) => {
+const group = async ({ params }: { params: Params }) => {
+  const { id } = await params;
   const supabase = await createClient();
 
   const {

--- a/app/group/[id]/page.tsx
+++ b/app/group/[id]/page.tsx
@@ -7,7 +7,7 @@ interface Params {
   id: number;
 }
 
-const group = async ({ params }: { params: Params }) => {
+const group = async ({ params }: { params: Promise<Params> }) => {
   const { id } = await params;
   const supabase = await createClient();
 


### PR DESCRIPTION
`params`から直接`id`に代入する動作を非同期処理で実行するように変更しました