### PR TITLE
グループ離脱時に再確認画面を出す

### DIFF
--- a/app/components/group-chat/chatApp.module.css
+++ b/app/components/group-chat/chatApp.module.css
@@ -36,6 +36,34 @@
   border-radius: 50%;
 }
 
+.leave_group_confirm {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 300px;
+  height: 200px;
+  background-color: #333;
+  border-radius: 5px;
+  color: white;
+  font-size: 20px;
+  text-align: center;
+}
+.leave_group_confirm_hide {
+  display: none;
+}
+.leave_confirm_btn {
+  margin: 0 15px;
+  width: 100px;
+  height: 40px;
+  border: 2px solid white;
+  border-radius: 5px;
+  background-color: #333;
+  color: white;
+  cursor: pointer;
+  margin-top: 20px;
+}
+
 .chat_form {
   position: fixed;
   display: flex;

--- a/app/components/group-chat/chatApp.tsx
+++ b/app/components/group-chat/chatApp.tsx
@@ -29,6 +29,7 @@ const ChatApp = (props: Props) => {
   const [messages, setMessages] = useState<string>("");
   const [groupMembers, setGroupMembers] = useState<MemberProfile[]>([]);
   const [isShowMembers, setIsShowMembers] = useState<boolean>(false);
+  const [isShowLeaveGroup, setIsShowLeaveGroup] = useState<boolean>(false);
   const isUserAdmin = groupMembers.some(
     (member) => member.user_id === userId && member.role === "admin"
   );
@@ -119,6 +120,26 @@ const ChatApp = (props: Props) => {
           groupMembers={groupMembers}
         />
       </div>
+      <div
+        className={
+          isShowLeaveGroup
+            ? styles.leave_group_confirm
+            : styles.leave_group_confirm_hide
+        }
+      >
+        <p>グループから離脱しますか？</p>
+        <div className={styles.leave_group_btns}>
+          <button className={styles.leave_confirm_btn} onClick={leaveChatGroup}>
+            はい
+          </button>
+          <button
+            className={styles.leave_confirm_btn}
+            onClick={() => setIsShowLeaveGroup(false)}
+          >
+            いいえ
+          </button>
+        </div>
+      </div>
       <div className={styles.chat_form}>
         <button
           className={styles.member_list_btn}
@@ -141,8 +162,11 @@ const ChatApp = (props: Props) => {
             グループ解散
           </button>
         ) : (
-          <button className={styles.leave_group_btn} onClick={leaveChatGroup}>
-            退室
+          <button
+            className={styles.leave_group_btn}
+            onClick={() => setIsShowLeaveGroup((prevState) => !prevState)}
+          >
+            グループ離脱
           </button>
         )}
       </div>


### PR DESCRIPTION
ボタンを一回押すだけでグループから離脱する仕様から誤動作を防ぐため再確認画面を表示
「グループ退室」の文言も仕様がわかりやすいように「グループ離脱」の表記に修正
close #16 