### PR TITLE
"insertAavatarUrl"のスペルミスと関数名の修正

### DIFF
--- a/app/utils/supabase_function/chat.ts
+++ b/app/utils/supabase_function/chat.ts
@@ -1,5 +1,5 @@
 import { supabase } from "../supabase";
-import { insertAavatarUrl } from "./profile";
+import { formatAvatarUrl } from "./profile";
 import type {
   ChatWithAvatar,
   SupabaseResponse,
@@ -16,7 +16,7 @@ export const getChatList = async (
     return { data: null, error };
   }
   const messageData = data.map((chat) => {
-    const avatarUrl = insertAavatarUrl(chat.profiles.avatar_url);
+    const avatarUrl = formatAvatarUrl(chat.profiles.avatar_url);
     return {
       ...chat,
       avatar_url: avatarUrl,
@@ -42,7 +42,7 @@ export const addChat = async (
   if (error) {
     return { data: null, error };
   }
-  const avatarUrl = insertAavatarUrl(chat.profiles.avatar_url);
+  const avatarUrl = formatAvatarUrl(chat.profiles.avatar_url);
   const chatWithAvatar = {
     ...chat,
     avatar_url: avatarUrl,

--- a/app/utils/supabase_function/profile.ts
+++ b/app/utils/supabase_function/profile.ts
@@ -8,7 +8,7 @@ export const getAvatarUrl = (avatarUrl: string) => {
   return data.publicUrl;
 };
 
-export const insertAavatarUrl = (avatarUrl: string | null) => {
+export const formatAvatarUrl = (avatarUrl: string | null) => {
   return avatarUrl ? getAvatarUrl(avatarUrl) : DEFAULT_AVATAR_URL;
 };
 


### PR DESCRIPTION
"insertAavatarUrl"の”Avatar”部分のスペルミス修正
同時に関数名で機能をわかりやすくするために”insert”の部分を”format”に変更
”insertAvatarUrl”→”formatAvatarUrl”
close #25 