### PR TITLE
navigation.tsxのavatarUrlの取得にformatAvatarUrl()を使用する

### DIFF
--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import { createClient } from "@/utils/supabase/server";
 import styles from "./navigation.module.css";
 import {
-  getAvatarUrl,
   DEFAULT_AVATAR_URL,
+  formatAvatarUrl,
 } from "@/app/utils/supabase_function/profile";
 import type { Profile } from "@/app/types/groupchat-types";
 
@@ -26,11 +26,9 @@ const Navigation = async () => {
     profile = userProfile;
   }
 
-  let avatarUrl = DEFAULT_AVATAR_URL;
-
-  if (profile?.avatar_url) {
-    avatarUrl = getAvatarUrl(profile.avatar_url);
-  }
+  let avatarUrl = profile
+    ? formatAvatarUrl(profile.avatar_url)
+    : DEFAULT_AVATAR_URL;
 
   return (
     <header className={styles.header}>

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -26,9 +26,7 @@ const Navigation = async () => {
     profile = userProfile;
   }
 
-  let avatarUrl = profile
-    ? formatAvatarUrl(profile.avatar_url)
-    : DEFAULT_AVATAR_URL;
+  let avatarUrl = formatAvatarUrl(profile?.avatar_url);
 
   return (
     <header className={styles.header}>

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -2,10 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { createClient } from "@/utils/supabase/server";
 import styles from "./navigation.module.css";
-import {
-  DEFAULT_AVATAR_URL,
-  formatAvatarUrl,
-} from "@/app/utils/supabase_function/profile";
+import { formatAvatarUrl } from "@/app/utils/supabase_function/profile";
 import type { Profile } from "@/app/types/groupchat-types";
 
 const Navigation = async () => {
@@ -26,7 +23,7 @@ const Navigation = async () => {
     profile = userProfile;
   }
 
-  let avatarUrl = formatAvatarUrl(profile?.avatar_url);
+  const avatarUrl = formatAvatarUrl(profile?.avatar_url);
 
   return (
     <header className={styles.header}>

--- a/app/utils/supabase_function/profile.ts
+++ b/app/utils/supabase_function/profile.ts
@@ -8,7 +8,7 @@ export const getAvatarUrl = (avatarUrl: string) => {
   return data.publicUrl;
 };
 
-export const formatAvatarUrl = (avatarUrl: string | null) => {
+export const formatAvatarUrl = (avatarUrl: string | null | undefined) => {
   return avatarUrl ? getAvatarUrl(avatarUrl) : DEFAULT_AVATAR_URL;
 };
 


### PR DESCRIPTION
アバター画像を取得する関数を直接使用せず回り道な記述になっていたので`formatAvatarUrl()`を使用した方法へ修正
profileがnullの際も自動でデフォルト画像が挿入されるように記述