### PR TITLE
[fix] insertAavatarUrl から formatAvatarUrl へ変更し忘れの修正

### DIFF
--- a/app/utils/supabase_function/group.ts
+++ b/app/utils/supabase_function/group.ts
@@ -1,5 +1,5 @@
 import { supabase } from "../supabase";
-import { insertAavatarUrl } from "./profile";
+import { formatAvatarUrl } from "./profile";
 import type {
   Group,
   GroupMember,
@@ -55,7 +55,7 @@ export const getGroupMember = async (
     return { data: null, error };
   }
   const memberProfiles = members.map((member) => {
-    const avatarUrl = insertAavatarUrl(member.profiles.avatar_url);
+    const avatarUrl = formatAvatarUrl(member.profiles.avatar_url);
     return {
       ...member,
       avatar_url: avatarUrl,


### PR DESCRIPTION
group.ts内で関数名をformatAvatarUrlに変更した部分が一部insertAavatarUrl のままだったのを修正
close #29 